### PR TITLE
Fixes typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Creating one big module does not really give a benefit of modules. Therefore the
 
 Details regarding how a module works or why it is setup is described in the module itself if needed.
 
-Modules need to be used to create infrastructure. For an example on how to use the modules to create a working ECS cluster see **ecs.tf** and **ecf.tfvars**.
+Modules need to be used to create infrastructure. For an example on how to use the modules to create a working ECS cluster see **ecs.tf** and **ecs.tfvars**.
 
 **Note:** You need to use Terraform version 0.9.5 and above
 
@@ -84,7 +84,7 @@ These are the conventions we have in every module
 
 ## Create it
 
-To create a working ECS cluster from this repository see **ecs.tf** and **ecf.tfvars**.
+To create a working ECS cluster from this repository see **ecs.tf** and **ecs.tfvars**.
 
 Quick way to create this from the repository as is:
 

--- a/ecs.tf
+++ b/ecs.tf
@@ -11,7 +11,7 @@ module "ecs" {
   vpc_cidr             = "${var.vpc_cidr}"
   public_subnet_cidrs  = "${var.public_subnet_cidrs}"
   private_subnet_cidrs = "${var.private_subnet_cidrs}"
-  availibility_zones   = "${var.availibility_zones}"
+  availability_zones   = "${var.availability_zones}"
   max_size             = "${var.max_size}"
   min_size             = "${var.min_size}"
   desired_capacity     = "${var.desired_capacity}"
@@ -41,7 +41,7 @@ variable "public_subnet_cidrs" {
   type = "list"
 }
 
-variable "availibility_zones" {
+variable "availability_zones" {
   type = "list"
 }
 

--- a/ecs.tfvars
+++ b/ecs.tfvars
@@ -6,7 +6,7 @@ public_subnet_cidrs = ["10.0.0.0/24", "10.0.1.0/24"]
 
 private_subnet_cidrs = ["10.0.50.0/24", "10.0.51.0/24"]
 
-availibility_zones = ["eu-west-1a", "eu-west-1b"]
+availability_zones = ["eu-west-1a", "eu-west-1b"]
 
 max_size = 1
 

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -4,7 +4,7 @@ module "network" {
   vpc_cidr             = "${var.vpc_cidr}"
   public_subnet_cidrs  = "${var.public_subnet_cidrs}"
   private_subnet_cidrs = "${var.private_subnet_cidrs}"
-  availibility_zones   = "${var.availibility_zones}"
+  availability_zones   = "${var.availability_zones}"
   depends_id           = ""
 }
 

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -32,7 +32,7 @@ variable "load_balancers" {
   description = "The load balancers to couple to the instances"
 }
 
-variable "availibility_zones" {
+variable "availability_zones" {
   type        = "list"
   description = "List of avalibility zones you want. Example: eu-west-1a and eu-west-1b"
 }

--- a/modules/ecs_instances/templates/user_data.sh
+++ b/modules/ecs_instances/templates/user_data.sh
@@ -88,7 +88,7 @@ EOF
 start ecs
 
 #Get ECS instance info, althoug not used in this user_data it self this allows you to use
-#az(availibility zone) and region
+#az(availability zone) and region
 until $(curl --output /dev/null --silent --head --fail http://localhost:51678/v1/metadata); do
   printf '.'
   sleep 5

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -12,7 +12,7 @@ module "private_subnet" {
   environment        = "${var.environment}"
   vpc_id             = "${module.vpc.id}"
   cidrs              = "${var.private_subnet_cidrs}"
-  availibility_zones = "${var.availibility_zones}"
+  availability_zones = "${var.availability_zones}"
 }
 
 module "public_subnet" {
@@ -22,7 +22,7 @@ module "public_subnet" {
   environment        = "${var.environment}"
   vpc_id             = "${module.vpc.id}"
   cidrs              = "${var.public_subnet_cidrs}"
-  availibility_zones = "${var.availibility_zones}"
+  availability_zones = "${var.availability_zones}"
 }
 
 module "nat" {

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -21,7 +21,7 @@ variable "public_subnet_cidrs" {
   description = "List of public cidrs, for every avalibility zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
 }
 
-variable "availibility_zones" {
+variable "availability_zones" {
   type        = "list"
   description = "List of avalibility zones you want. Example: eu-west-1a and eu-west-1b"
 }

--- a/modules/subnet/main.tf
+++ b/modules/subnet/main.tf
@@ -3,11 +3,11 @@
 resource "aws_subnet" "subnet" {
   vpc_id            = "${var.vpc_id}"
   cidr_block        = "${element(var.cidrs, count.index)}"
-  availability_zone = "${element(var.availibility_zones, count.index)}"
+  availability_zone = "${element(var.availability_zones, count.index)}"
   count             = "${length(var.cidrs)}"
 
   tags {
-    Name        = "${var.name}_${element(var.availibility_zones, count.index)}"
+    Name        = "${var.name}_${element(var.availability_zones, count.index)}"
     Environment = "${var.environment}"
   }
 }
@@ -20,7 +20,7 @@ resource "aws_route_table" "subnet" {
   count  = "${length(var.cidrs)}"
 
   tags {
-    Name        = "${var.name}_${element(var.availibility_zones, count.index)}"
+    Name        = "${var.name}_${element(var.availability_zones, count.index)}"
     Environment = "${var.environment}"
   }
 }

--- a/modules/subnet/variables.tf
+++ b/modules/subnet/variables.tf
@@ -11,7 +11,7 @@ variable "cidrs" {
   description = "List of cidrs, for every avalibility zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
 }
 
-variable "availibility_zones" {
+variable "availability_zones" {
   type        = "list"
   description = "List of avalibility zones you want. Example: eu-west-1a and eu-west-1b"
 }


### PR DESCRIPTION
Fixes some mentions of "ecf" instead of "ecs" in the README, and replaces "availibility" with "availability" throughout the module.