### PR TITLE
#25 terraform 0.12 syntax changes

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "ecs" {
-  source = "modules/ecs"
+  source = "./modules/ecs"
 
   environment          = "${var.environment}"
   cluster              = "${var.environment}"

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -12,17 +12,17 @@ resource "aws_alb_target_group" "default" {
     protocol = "HTTP"
   }
 
-  tags {
+  tags = {
     Environment = "${var.environment}"
   }
 }
 
 resource "aws_alb" "alb" {
   name            = "${var.alb_name}"
-  subnets         = ["${var.public_subnet_ids}"]
+  subnets         = "${var.public_subnet_ids}"
   security_groups = ["${aws_security_group.alb.id}"]
 
-  tags {
+  tags = {
     Environment = "${var.environment}"
   }
 }
@@ -42,7 +42,7 @@ resource "aws_security_group" "alb" {
   name   = "${var.alb_name}_alb"
   vpc_id = "${var.vpc_id}"
 
-  tags {
+  tags = {
     Environment = "${var.environment}"
   }
 }

--- a/modules/ecs_instances/main.tf
+++ b/modules/ecs_instances/main.tf
@@ -8,7 +8,7 @@ resource "aws_security_group" "instance" {
   description = "Used in ${var.environment}"
   vpc_id      = "${var.vpc_id}"
 
-  tags {
+  tags = {
     Environment   = "${var.environment}"
     Cluster       = "${var.cluster}"
     InstanceGroup = "${var.instance_group}"
@@ -52,8 +52,8 @@ resource "aws_autoscaling_group" "asg" {
   desired_capacity     = "${var.desired_capacity}"
   force_delete         = true
   launch_configuration = "${aws_launch_configuration.launch.id}"
-  vpc_zone_identifier  = ["${var.private_subnet_ids}"]
-  load_balancers       = ["${var.load_balancers}"]
+  vpc_zone_identifier  = "${var.private_subnet_ids}"
+  load_balancers       = "${var.load_balancers}"
 
   tag {
     key                 = "Name"
@@ -91,7 +91,7 @@ resource "aws_autoscaling_group" "asg" {
 data "template_file" "user_data" {
   template = "${file("${path.module}/templates/user_data.sh")}"
 
-  vars {
+  vars = {
     ecs_config        = "${var.ecs_config}"
     ecs_logging       = "${var.ecs_logging}"
     cluster_name      = "${var.cluster}"

--- a/modules/nat_gateway/outputs.tf
+++ b/modules/nat_gateway/outputs.tf
@@ -1,3 +1,3 @@
 output "ids" {
-  value = ["${aws_nat_gateway.nat.*.id}"]
+  value = "${aws_nat_gateway.nat.*.id}"
 }

--- a/modules/subnet/main.tf
+++ b/modules/subnet/main.tf
@@ -6,7 +6,7 @@ resource "aws_subnet" "subnet" {
   availability_zone = "${element(var.availability_zones, count.index)}"
   count             = "${length(var.cidrs)}"
 
-  tags {
+  tags = {
     Name        = "${var.name}_${element(var.availability_zones, count.index)}"
     Environment = "${var.environment}"
   }
@@ -19,7 +19,7 @@ resource "aws_route_table" "subnet" {
   vpc_id = "${var.vpc_id}"
   count  = "${length(var.cidrs)}"
 
-  tags {
+  tags = {
     Name        = "${var.name}_${element(var.availability_zones, count.index)}"
     Environment = "${var.environment}"
   }

--- a/modules/subnet/outputs.tf
+++ b/modules/subnet/outputs.tf
@@ -1,11 +1,7 @@
 output "ids" {
-  value = [
-    "${aws_subnet.subnet.*.id}",
-  ]
+  value = "${aws_subnet.subnet.*.id}"
 }
 
 output "route_table_ids" {
-  value = [
-    "${aws_route_table.subnet.*.id}",
-  ]
+  value = "${aws_route_table.subnet.*.id}"
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -2,7 +2,7 @@ resource "aws_vpc" "vpc" {
   cidr_block           = "${var.cidr}"
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name        = "${var.environment}"
     Environment = "${var.environment}"
   }
@@ -11,7 +11,7 @@ resource "aws_vpc" "vpc" {
 resource "aws_internet_gateway" "vpc" {
   vpc_id = "${aws_vpc.vpc.id}"
 
-  tags {
+  tags = {
     Environment = "${var.environment}"
   }
 }


### PR DESCRIPTION
With these changes, modules will work with terraform 0.12, but won't be compatible with older versions any more. 