### PR TITLE
Fixed Nat and Subnet

### DIFF
--- a/modules/subnet/outputs.tf
+++ b/modules/subnet/outputs.tf
@@ -1,11 +1,8 @@
 output "ids" {
-  value = [
-    "${aws_subnet.subnet.*.id}",
-  ]
+  value = "${aws_subnet.subnet.*.id}"
 }
 
 output "route_table_ids" {
-  value = [
-    "${aws_route_table.subnet.*.id}",
+  value = "${aws_route_table.subnet.*.id}"
   ]
 }


### PR DESCRIPTION
The nat creation was failing with terraform 12 , one of the reason was brackets and other was variable was extended to next line