### PR TITLE
Terraform v0.12.0, v0.13.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 aws.tf
 .terraform
 terraform.tfstate*
+.idea/

--- a/ecs.tf
+++ b/ecs.tf
@@ -3,21 +3,21 @@ provider "aws" {
 }
 
 module "ecs" {
-  source = "modules/ecs"
+  source = "./modules/ecs"
 
-  environment          = "${var.environment}"
-  cluster              = "${var.environment}"
+  environment          = var.environment
+  cluster              = var.environment
   cloudwatch_prefix    = "${var.environment}"           #See ecs_instances module when to set this and when not!
-  vpc_cidr             = "${var.vpc_cidr}"
-  public_subnet_cidrs  = "${var.public_subnet_cidrs}"
-  private_subnet_cidrs = "${var.private_subnet_cidrs}"
-  availability_zones   = "${var.availability_zones}"
-  max_size             = "${var.max_size}"
-  min_size             = "${var.min_size}"
-  desired_capacity     = "${var.desired_capacity}"
-  key_name             = "${aws_key_pair.ecs.key_name}"
-  instance_type        = "${var.instance_type}"
-  ecs_aws_ami          = "${var.ecs_aws_ami}"
+  vpc_cidr             = var.vpc_cidr
+  public_subnet_cidrs  = var.public_subnet_cidrs
+  private_subnet_cidrs = var.private_subnet_cidrs
+  availability_zones   = var.availability_zones
+  max_size             = var.max_size
+  min_size             = var.min_size
+  desired_capacity     = var.desired_capacity
+  key_name             = aws_key_pair.ecs.key_name
+  instance_type        = var.instance_type
+  ecs_aws_ami          = var.ecs_aws_ami
 }
 
 resource "aws_key_pair" "ecs" {
@@ -34,17 +34,17 @@ variable "instance_type" {}
 variable "ecs_aws_ami" {}
 
 variable "private_subnet_cidrs" {
-  type = "list"
+  type = list
 }
 
 variable "public_subnet_cidrs" {
-  type = "list"
+  type = list
 }
 
 variable "availability_zones" {
-  type = "list"
+  type = list
 }
 
 output "default_alb_target_group" {
-  value = "${module.ecs.default_alb_target_group}"
+  value = module.ecs.default_alb_target_group
 }

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -4,46 +4,46 @@ resource "aws_alb_target_group" "default" {
   name                 = "${var.alb_name}-default"
   port                 = 80
   protocol             = "HTTP"
-  vpc_id               = "${var.vpc_id}"
-  deregistration_delay = "${var.deregistration_delay}"
+  vpc_id               = var.vpc_id
+  deregistration_delay = var.deregistration_delay
 
   health_check {
-    path     = "${var.health_check_path}"
+    path     = var.health_check_path
     protocol = "HTTP"
   }
 
-  tags {
-    Environment = "${var.environment}"
+  tags = {
+    Environment = var.environment
   }
 }
 
 resource "aws_alb" "alb" {
-  name            = "${var.alb_name}"
-  subnets         = ["${var.public_subnet_ids}"]
+  name            = var.alb_name
+  subnets         = var.public_subnet_ids
   security_groups = ["${aws_security_group.alb.id}"]
 
-  tags {
-    Environment = "${var.environment}"
+  tags = {
+    Environment = var.environment
   }
 }
 
 resource "aws_alb_listener" "http" {
-  load_balancer_arn = "${aws_alb.alb.id}"
+  load_balancer_arn = aws_alb.alb.id
   port              = "80"
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = "${aws_alb_target_group.default.id}"
+    target_group_arn = aws_alb_target_group.default.id
     type             = "forward"
   }
 }
 
 resource "aws_security_group" "alb" {
   name   = "${var.alb_name}_alb"
-  vpc_id = "${var.vpc_id}"
+  vpc_id = var.vpc_id
 
-  tags {
-    Environment = "${var.environment}"
+  tags = {
+    Environment = var.environment
   }
 }
 
@@ -52,8 +52,8 @@ resource "aws_security_group_rule" "https_from_anywhere" {
   from_port         = 80
   to_port           = 80
   protocol          = "TCP"
-  cidr_blocks       = ["${var.allow_cidr_block}"]
-  security_group_id = "${aws_security_group.alb.id}"
+  cidr_blocks       = var.allow_cidr_block
+  security_group_id = aws_security_group.alb.id
 }
 
 resource "aws_security_group_rule" "outbound_internet_access" {
@@ -62,5 +62,5 @@ resource "aws_security_group_rule" "outbound_internet_access" {
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.alb.id}"
+  security_group_id = aws_security_group.alb.id
 }

--- a/modules/alb/outputs.tf
+++ b/modules/alb/outputs.tf
@@ -1,7 +1,7 @@
 output "alb_security_group_id" {
-  value = "${aws_security_group.alb.id}"
+  value = aws_security_group.alb.id
 }
 
 output "default_alb_target_group" {
-  value = "${aws_alb_target_group.default.arn}"
+  value = aws_alb_target_group.default.arn
 }

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -8,7 +8,7 @@ variable "environment" {
 }
 
 variable "public_subnet_ids" {
-  type        = "list"
+  type        = list
   description = "List of public subnet ids to place the loadbalancer in"
 }
 
@@ -27,6 +27,6 @@ variable "health_check_path" {
 }
 
 variable "allow_cidr_block" {
-  default     = "0.0.0.0/0"
-  description = "Specify cird block that is allowd to acces the LoadBalancer"
+  default     = ["0.0.0.0/0"]
+  description = "Specify cidr block that is allowed to access the LoadBalancer"
 }

--- a/modules/ecs/alb.tf
+++ b/modules/ecs/alb.tf
@@ -1,10 +1,10 @@
 module "alb" {
   source = "../alb"
 
-  environment       = "${var.environment}"
+  environment       = var.environment
   alb_name          = "${var.environment}-${var.cluster}"
-  vpc_id            = "${module.network.vpc_id}"
-  public_subnet_ids = "${module.network.public_subnet_ids}"
+  vpc_id            = module.network.vpc_id
+  public_subnet_ids = module.network.public_subnet_ids
 }
 
 resource "aws_security_group_rule" "alb_to_ecs" {
@@ -12,6 +12,6 @@ resource "aws_security_group_rule" "alb_to_ecs" {
   from_port                = 32768
   to_port                  = 61000
   protocol                 = "TCP"
-  source_security_group_id = "${module.alb.alb_security_group_id}"
-  security_group_id        = "${module.ecs_instances.ecs_instance_security_group_id}"
+  source_security_group_id = module.alb.alb_security_group_id
+  security_group_id        = module.ecs_instances.ecs_instance_security_group_id
 }

--- a/modules/ecs/instance_policy.tf
+++ b/modules/ecs/instance_policy.tf
@@ -24,15 +24,15 @@ EOF
 resource "aws_iam_instance_profile" "ecs" {
   name = "${var.environment}_ecs_instance_profile"
   path = "/"
-  role = "${aws_iam_role.ecs_instance_role.name}"
+  role = aws_iam_role.ecs_instance_role.name
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_ec2_role" {
-  role       = "${aws_iam_role.ecs_instance_role.id}"
+  role       = aws_iam_role.ecs_instance_role.id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_ec2_cloudwatch_role" {
-  role       = "${aws_iam_role.ecs_instance_role.id}"
+  role       = aws_iam_role.ecs_instance_role.id
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
 }

--- a/modules/ecs/loadbalancer_policy.tf
+++ b/modules/ecs/loadbalancer_policy.tf
@@ -19,6 +19,6 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_lb" {
-  role       = "${aws_iam_role.ecs_lb_role.id}"
+  role       = aws_iam_role.ecs_lb_role.id
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
 }

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -1,34 +1,34 @@
 module "network" {
   source               = "../network"
-  environment          = "${var.environment}"
-  vpc_cidr             = "${var.vpc_cidr}"
-  public_subnet_cidrs  = "${var.public_subnet_cidrs}"
-  private_subnet_cidrs = "${var.private_subnet_cidrs}"
-  availability_zones   = "${var.availability_zones}"
+  environment          = var.environment
+  vpc_cidr             = var.vpc_cidr
+  public_subnet_cidrs  = var.public_subnet_cidrs
+  private_subnet_cidrs = var.private_subnet_cidrs
+  availability_zones   = var.availability_zones
   depends_id           = ""
 }
 
 module "ecs_instances" {
   source = "../ecs_instances"
 
-  environment             = "${var.environment}"
-  cluster                 = "${var.cluster}"
-  instance_group          = "${var.instance_group}"
-  private_subnet_ids      = "${module.network.private_subnet_ids}"
-  aws_ami                 = "${var.ecs_aws_ami}"
-  instance_type           = "${var.instance_type}"
-  max_size                = "${var.max_size}"
-  min_size                = "${var.min_size}"
-  desired_capacity        = "${var.desired_capacity}"
-  vpc_id                  = "${module.network.vpc_id}"
-  iam_instance_profile_id = "${aws_iam_instance_profile.ecs.id}"
-  key_name                = "${var.key_name}"
-  load_balancers          = "${var.load_balancers}"
-  depends_id              = "${module.network.depends_id}"
-  custom_userdata         = "${var.custom_userdata}"
-  cloudwatch_prefix       = "${var.cloudwatch_prefix}"
+  environment             = var.environment
+  cluster                 = var.cluster
+  instance_group          = var.instance_group
+  private_subnet_ids      = module.network.private_subnet_ids
+  aws_ami                 = var.ecs_aws_ami
+  instance_type           = var.instance_type
+  max_size                = var.max_size
+  min_size                = var.min_size
+  desired_capacity        = var.desired_capacity
+  vpc_id                  = module.network.vpc_id
+  iam_instance_profile_id = aws_iam_instance_profile.ecs.id
+  key_name                = var.key_name
+  load_balancers          = var.load_balancers
+  depends_id              = module.network.depends_id
+  custom_userdata         = var.custom_userdata
+  cloudwatch_prefix       = var.cloudwatch_prefix
 }
 
 resource "aws_ecs_cluster" "cluster" {
-  name = "${var.cluster}"
+  name = var.cluster
 }

--- a/modules/ecs/outputs.tf
+++ b/modules/ecs/outputs.tf
@@ -1,3 +1,3 @@
 output "default_alb_target_group" {
-  value = "${module.alb.default_alb_target_group}"
+  value = module.alb.default_alb_target_group
 }

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -17,23 +17,23 @@ variable "vpc_cidr" {
 }
 
 variable "private_subnet_cidrs" {
-  type        = "list"
+  type        = list
   description = "List of private cidrs, for every avalibility zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
 }
 
 variable "public_subnet_cidrs" {
-  type        = "list"
+  type        = list
   description = "List of public cidrs, for every avalibility zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
 }
 
 variable "load_balancers" {
-  type        = "list"
+  type        = list
   default     = []
   description = "The load balancers to couple to the instances"
 }
 
 variable "availability_zones" {
-  type        = "list"
+  type        = list
   description = "List of avalibility zones you want. Example: eu-west-1a and eu-west-1b"
 }
 

--- a/modules/ecs_events/main.tf
+++ b/modules/ecs_events/main.tf
@@ -22,20 +22,20 @@ data "template_file" "ecs_task_stopped" {
 EOF
 
   vars {
-    account_id = "${data.aws_caller_identity.current.account_id}"
-    cluster    = "${var.cluster}"
-    aws_region = "${data.aws_region.current.name}"
+    account_id = data.aws_caller_identity.current.account_id
+    cluster    = var.cluster
+    aws_region = data.aws_region.current.name
   }
 }
 
 resource "aws_cloudwatch_event_rule" "ecs_task_stopped" {
   name          = "${var.environment}_${var.cluster}_task_stopped"
   description   = "${var.environment}_${var.cluster} Essential container in task exited"
-  event_pattern = "${data.template_file.ecs_task_stopped.rendered}"
+  event_pattern = data.template_file.ecs_task_stopped.rendered
 }
 
 resource "aws_cloudwatch_event_target" "event_fired" {
-  rule  = "${aws_cloudwatch_event_rule.ecs_task_stopped.name}"
-  arn   = "${aws_sns_topic.ecs_events.arn}"
+  rule  = aws_cloudwatch_event_rule.ecs_task_stopped.name
+  arn   = aws_sns_topic.ecs_events.arn
   input = "{ \"message\": \"Essential container in task exited\", \"account_id\": \"${data.aws_caller_identity.current.account_id}\", \"cluster\": \"${var.cluster}\"}"
 }

--- a/modules/ecs_instances/main.tf
+++ b/modules/ecs_instances/main.tf
@@ -6,12 +6,12 @@
 resource "aws_security_group" "instance" {
   name        = "${var.environment}_${var.cluster}_${var.instance_group}"
   description = "Used in ${var.environment}"
-  vpc_id      = "${var.vpc_id}"
+  vpc_id      = var.vpc_id
 
-  tags {
-    Environment   = "${var.environment}"
-    Cluster       = "${var.cluster}"
-    InstanceGroup = "${var.instance_group}"
+  tags = {
+    Environment   = var.environment
+    Cluster       = var.cluster
+    InstanceGroup = var.instance_group
   }
 }
 
@@ -23,18 +23,18 @@ resource "aws_security_group_rule" "outbound_internet_access" {
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.instance.id}"
+  security_group_id = aws_security_group.instance.id
 }
 
 # Default disk size for Docker is 22 gig, see http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
 resource "aws_launch_configuration" "launch" {
   name_prefix          = "${var.environment}_${var.cluster}_${var.instance_group}_"
-  image_id             = "${var.aws_ami}"
-  instance_type        = "${var.instance_type}"
+  image_id             = var.aws_ami
+  instance_type        = var.instance_type
   security_groups      = ["${aws_security_group.instance.id}"]
-  user_data            = "${data.template_file.user_data.rendered}"
-  iam_instance_profile = "${var.iam_instance_profile_id}"
-  key_name             = "${var.key_name}"
+  user_data            = data.template_file.user_data.rendered
+  iam_instance_profile = var.iam_instance_profile_id
+  key_name             = var.key_name
 
   # aws_launch_configuration can not be modified.
   # Therefore we use create_before_destroy so that a new modified aws_launch_configuration can be created 
@@ -47,13 +47,13 @@ resource "aws_launch_configuration" "launch" {
 # Instances are scaled across availability zones http://docs.aws.amazon.com/autoscaling/latest/userguide/auto-scaling-benefits.html 
 resource "aws_autoscaling_group" "asg" {
   name                 = "${var.environment}_${var.cluster}_${var.instance_group}"
-  max_size             = "${var.max_size}"
-  min_size             = "${var.min_size}"
-  desired_capacity     = "${var.desired_capacity}"
+  max_size             = var.max_size
+  min_size             = var.min_size
+  desired_capacity     = var.desired_capacity
   force_delete         = true
-  launch_configuration = "${aws_launch_configuration.launch.id}"
-  vpc_zone_identifier  = ["${var.private_subnet_ids}"]
-  load_balancers       = ["${var.load_balancers}"]
+  launch_configuration = aws_launch_configuration.launch.id
+  vpc_zone_identifier  = var.private_subnet_ids
+  load_balancers       = var.load_balancers
 
   tag {
     key                 = "Name"
@@ -63,19 +63,19 @@ resource "aws_autoscaling_group" "asg" {
 
   tag {
     key                 = "Environment"
-    value               = "${var.environment}"
+    value               = var.environment
     propagate_at_launch = "true"
   }
 
   tag {
     key                 = "Cluster"
-    value               = "${var.cluster}"
+    value               = var.cluster
     propagate_at_launch = "true"
   }
 
   tag {
     key                 = "InstanceGroup"
-    value               = "${var.instance_group}"
+    value               = var.instance_group
     propagate_at_launch = "true"
   }
 
@@ -83,7 +83,7 @@ resource "aws_autoscaling_group" "asg" {
   # For info why see description in the network module.
   tag {
     key                 = "DependsId"
-    value               = "${var.depends_id}"
+    value               = var.depends_id
     propagate_at_launch = "false"
   }
 }
@@ -91,12 +91,12 @@ resource "aws_autoscaling_group" "asg" {
 data "template_file" "user_data" {
   template = "${file("${path.module}/templates/user_data.sh")}"
 
-  vars {
-    ecs_config        = "${var.ecs_config}"
-    ecs_logging       = "${var.ecs_logging}"
-    cluster_name      = "${var.cluster}"
-    env_name          = "${var.environment}"
-    custom_userdata   = "${var.custom_userdata}"
-    cloudwatch_prefix = "${var.cloudwatch_prefix}"
+  vars = {
+    ecs_config        = var.ecs_config
+    ecs_logging       = var.ecs_logging
+    cluster_name      = var.cluster
+    env_name          = var.environment
+    custom_userdata   = var.custom_userdata
+    cloudwatch_prefix = var.cloudwatch_prefix
   }
 }

--- a/modules/ecs_instances/outputs.tf
+++ b/modules/ecs_instances/outputs.tf
@@ -1,3 +1,3 @@
 output "ecs_instance_security_group_id" {
-  value = "${aws_security_group.instance.id}"
+  value = aws_security_group.instance.id
 }

--- a/modules/ecs_instances/variables.tf
+++ b/modules/ecs_instances/variables.tf
@@ -50,12 +50,12 @@ variable "iam_instance_profile_id" {
 }
 
 variable "private_subnet_ids" {
-  type        = "list"
+  type        = list
   description = "The list of private subnets to place the instances in"
 }
 
 variable "load_balancers" {
-  type        = "list"
+  type        = list
   default     = []
   description = "The load balancers to couple to the instances. Only used when NOT using ALB"
 }

--- a/modules/ecs_roles/main.tf
+++ b/modules/ecs_roles/main.tf
@@ -44,9 +44,9 @@ data "template_file" "policy" {
 EOF
 
   vars {
-    account_id = "${data.aws_caller_identity.current.account_id}"
-    prefix     = "${var.prefix}"
-    aws_region = "${data.aws_region.current.name}"
+    account_id = data.aws_caller_identity.current.account_id
+    prefix     = var.prefix
+    aws_region = data.aws_region.current.name
   }
 }
 
@@ -54,11 +54,11 @@ resource "aws_iam_policy" "ecs_default_task" {
   name = "${var.environment}_${var.cluster}_ecs_default_task"
   path = "/"
 
-  policy = "${data.template_file.policy.rendered}"
+  policy = data.template_file.policy.rendered
 }
 
 resource "aws_iam_policy_attachment" "ecs_default_task" {
   name       = "${var.environment}_${var.cluster}_ecs_default_task"
   roles      = ["${aws_iam_role.ecs_default_task.name}"]
-  policy_arn = "${aws_iam_policy.ecs_default_task.arn}"
+  policy_arn = aws_iam_policy.ecs_default_task.arn
 }

--- a/modules/nat_gateway/main.tf
+++ b/modules/nat_gateway/main.tf
@@ -2,12 +2,12 @@
 # See comparison http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-comparison.html
 
 resource "aws_nat_gateway" "nat" {
-  allocation_id = "${element(aws_eip.nat.*.id, count.index)}"
-  subnet_id     = "${element(var.subnet_ids, count.index)}"
-  count         = "${var.subnet_count}"
+  allocation_id = element(aws_eip.nat.*.id, count.index)
+  subnet_id     = element(var.subnet_ids, count.index)
+  count         = var.subnet_count
 }
 
 resource "aws_eip" "nat" {
   vpc   = true
-  count = "${var.subnet_count}"
+  count = var.subnet_count
 }

--- a/modules/nat_gateway/outputs.tf
+++ b/modules/nat_gateway/outputs.tf
@@ -1,3 +1,3 @@
 output "ids" {
-  value = ["${aws_nat_gateway.nat.*.id}"]
+  value = "${aws_nat_gateway.nat.*.id}"
 }

--- a/modules/nat_gateway/variables.tf
+++ b/modules/nat_gateway/variables.tf
@@ -1,5 +1,5 @@
 variable "subnet_ids" {
-  type        = "list"
+  type        = list
   description = "List of subnets in which to place the NAT Gateway"
 }
 

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -1,49 +1,49 @@
 module "vpc" {
   source = "../vpc"
 
-  cidr        = "${var.vpc_cidr}"
-  environment = "${var.environment}"
+  cidr        = var.vpc_cidr
+  environment = var.environment
 }
 
 module "private_subnet" {
   source = "../subnet"
 
   name               = "${var.environment}_private_subnet"
-  environment        = "${var.environment}"
-  vpc_id             = "${module.vpc.id}"
-  cidrs              = "${var.private_subnet_cidrs}"
-  availability_zones = "${var.availability_zones}"
+  environment        = var.environment
+  vpc_id             = module.vpc.id
+  cidrs              = var.private_subnet_cidrs
+  availability_zones = var.availability_zones
 }
 
 module "public_subnet" {
   source = "../subnet"
 
   name               = "${var.environment}_public_subnet"
-  environment        = "${var.environment}"
-  vpc_id             = "${module.vpc.id}"
-  cidrs              = "${var.public_subnet_cidrs}"
-  availability_zones = "${var.availability_zones}"
+  environment        = var.environment
+  vpc_id             = module.vpc.id
+  cidrs              = var.public_subnet_cidrs
+  availability_zones = var.availability_zones
 }
 
 module "nat" {
   source = "../nat_gateway"
 
-  subnet_ids   = "${module.public_subnet.ids}"
-  subnet_count = "${length(var.public_subnet_cidrs)}"
+  subnet_ids   = module.public_subnet.ids
+  subnet_count = length(var.public_subnet_cidrs)
 }
 
 resource "aws_route" "public_igw_route" {
-  count                  = "${length(var.public_subnet_cidrs)}"
-  route_table_id         = "${element(module.public_subnet.route_table_ids, count.index)}"
-  gateway_id             = "${module.vpc.igw}"
-  destination_cidr_block = "${var.destination_cidr_block}"
+  count                  = length(var.public_subnet_cidrs)
+  route_table_id         = element(module.public_subnet.route_table_ids, count.index)
+  gateway_id             = module.vpc.igw
+  destination_cidr_block = var.destination_cidr_block
 }
 
 resource "aws_route" "private_nat_route" {
-  count                  = "${length(var.private_subnet_cidrs)}"
-  route_table_id         = "${element(module.private_subnet.route_table_ids, count.index)}"
-  nat_gateway_id         = "${element(module.nat.ids, count.index)}"
-  destination_cidr_block = "${var.destination_cidr_block}"
+  count                  = length(var.private_subnet_cidrs)
+  route_table_id         = element(module.private_subnet.route_table_ids, count.index)
+  nat_gateway_id         = element(module.nat.ids, count.index)
+  destination_cidr_block = var.destination_cidr_block
 }
 
 # Creating a NAT Gateway takes some time. Some services need the internet (NAT Gateway) before proceeding. 
@@ -52,5 +52,5 @@ resource "aws_route" "private_nat_route" {
 # Therefore we use a workaround described here: https://github.com/hashicorp/terraform/issues/1178#issuecomment-207369534
 
 resource "null_resource" "dummy_dependency" {
-  depends_on = ["module.nat"]
+  depends_on = [module.nat]
 }

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -1,19 +1,19 @@
 output "vpc_id" {
-  value = "${module.vpc.id}"
+  value = module.vpc.id
 }
 
 output "vpc_cidr" {
-  value = "${module.vpc.cidr_block}"
+  value = module.vpc.cidr_block
 }
 
 output "private_subnet_ids" {
-  value = "${module.private_subnet.ids}"
+  value = module.private_subnet.ids
 }
 
 output "public_subnet_ids" {
-  value = "${module.public_subnet.ids}"
+  value = module.public_subnet.ids
 }
 
 output "depends_id" {
-  value = "${null_resource.dummy_dependency.id}"
+  value = null_resource.dummy_dependency.id
 }

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -12,17 +12,17 @@ variable "destination_cidr_block" {
 }
 
 variable "private_subnet_cidrs" {
-  type        = "list"
+  type        = list
   description = "List of private cidrs, for every avalibility zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
 }
 
 variable "public_subnet_cidrs" {
-  type        = "list"
+  type        = list
   description = "List of public cidrs, for every avalibility zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
 }
 
 variable "availability_zones" {
-  type        = "list"
+  type        = list
   description = "List of avalibility zones you want. Example: eu-west-1a and eu-west-1b"
 }
 

--- a/modules/subnet/main.tf
+++ b/modules/subnet/main.tf
@@ -1,14 +1,14 @@
 # Modules that allows creating a subnet inside a VPC. This module can be used to create either a private or public-facing subnet
 
 resource "aws_subnet" "subnet" {
-  vpc_id            = "${var.vpc_id}"
-  cidr_block        = "${element(var.cidrs, count.index)}"
-  availability_zone = "${element(var.availability_zones, count.index)}"
-  count             = "${length(var.cidrs)}"
+  vpc_id            = var.vpc_id
+  cidr_block        = element(var.cidrs, count.index)
+  availability_zone = element(var.availability_zones, count.index)
+  count             = length(var.cidrs)
 
-  tags {
+  tags = {
     Name        = "${var.name}_${element(var.availability_zones, count.index)}"
-    Environment = "${var.environment}"
+    Environment = var.environment
   }
 }
 
@@ -16,17 +16,17 @@ resource "aws_subnet" "subnet" {
 # add all the subnets to it. This allows us to easier create routing to all the subnets at once.
 # For example when creating a route to the Internet Gateway 
 resource "aws_route_table" "subnet" {
-  vpc_id = "${var.vpc_id}"
-  count  = "${length(var.cidrs)}"
+  vpc_id = var.vpc_id
+  count  = length(var.cidrs)
 
-  tags {
+  tags = {
     Name        = "${var.name}_${element(var.availability_zones, count.index)}"
-    Environment = "${var.environment}"
+    Environment = var.environment
   }
 }
 
 resource "aws_route_table_association" "subnet" {
-  subnet_id      = "${element(aws_subnet.subnet.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.subnet.*.id, count.index)}"
-  count          = "${length(var.cidrs)}"
+  subnet_id      = element(aws_subnet.subnet.*.id, count.index)
+  route_table_id = element(aws_route_table.subnet.*.id, count.index)
+  count          = length(var.cidrs)
 }

--- a/modules/subnet/outputs.tf
+++ b/modules/subnet/outputs.tf
@@ -4,5 +4,4 @@ output "ids" {
 
 output "route_table_ids" {
   value = "${aws_route_table.subnet.*.id}"
-  ]
 }

--- a/modules/subnet/variables.tf
+++ b/modules/subnet/variables.tf
@@ -7,12 +7,12 @@ variable "environment" {
 }
 
 variable "cidrs" {
-  type        = "list"
+  type        = list
   description = "List of cidrs, for every avalibility zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
 }
 
 variable "availability_zones" {
-  type        = "list"
+  type        = list
   description = "List of avalibility zones you want. Example: eu-west-1a and eu-west-1b"
 }
 

--- a/modules/users/main.tf
+++ b/modules/users/main.tf
@@ -9,7 +9,7 @@ resource "aws_iam_user" "ecs_deployer" {
 # to have any roles in there with full admin rights, but no ECS task should have these rights!
 resource "aws_iam_user_policy" "ecs_deployer_policy" {
   name = "ecs_deployer_policy"
-  user = "${aws_iam_user.ecs_deployer.name}"
+  user = aws_iam_user.ecs_deployer.name
 
   policy = <<EOF
 {
@@ -39,5 +39,5 @@ EOF
 }
 
 resource "aws_iam_access_key" "ecs_deployer" {
-  user = "${aws_iam_user.ecs_deployer.name}"
+  user = aws_iam_user.ecs_deployer.name
 }

--- a/modules/users/outputs.tf
+++ b/modules/users/outputs.tf
@@ -1,7 +1,7 @@
 output "ecs_deployer_access_key" {
-  value = "${aws_iam_access_key.ecs_deployer.id}"
+  value = aws_iam_access_key.ecs_deployer.id
 }
 
 output "ecs_deployer_secret_key" {
-  value = "${aws_iam_access_key.ecs_deployer.secret}"
+  value = aws_iam_access_key.ecs_deployer.secret
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,17 +1,17 @@
 resource "aws_vpc" "vpc" {
-  cidr_block           = "${var.cidr}"
+  cidr_block           = var.cidr
   enable_dns_hostnames = true
 
-  tags {
-    Name        = "${var.environment}"
-    Environment = "${var.environment}"
+  tags = {
+    Name        = var.environment
+    Environment = var.environment
   }
 }
 
 resource "aws_internet_gateway" "vpc" {
-  vpc_id = "${aws_vpc.vpc.id}"
+  vpc_id = aws_vpc.vpc.id
 
-  tags {
-    Environment = "${var.environment}"
+  tags = {
+    Environment = var.environment
   }
 }

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,11 +1,11 @@
 output "id" {
-  value = "${aws_vpc.vpc.id}"
+  value = aws_vpc.vpc.id
 }
 
 output "cidr_block" {
-  value = "${aws_vpc.vpc.cidr_block}"
+  value = aws_vpc.vpc.cidr_block
 }
 
 output "igw" {
-  value = "${aws_internet_gateway.vpc.id}"
+  value = aws_internet_gateway.vpc.id
 }


### PR DESCRIPTION
This PR builds on top of https://github.com/arminc/terraform-ecs/pull/26 (I applied as a patch) as I found out that the PR did not cover a lot of validation and deprecation issues.

I've tested it to work on 0.12.0 and 0.13.0 (which I think just got released this week), and made it compatible for publishing to the Terraform registry.

The changes are *not* backwards compatible with older versions.

Addresses https://github.com/arminc/terraform-ecs/issues/25