### PR TITLE
Fix typos in variable descriptions.

### DIFF
--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -18,12 +18,12 @@ variable "vpc_cidr" {
 
 variable "private_subnet_cidrs" {
   type        = list
-  description = "List of private cidrs, for every avalibility zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
+  description = "List of private cidrs, for every availability zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
 }
 
 variable "public_subnet_cidrs" {
   type        = list
-  description = "List of public cidrs, for every avalibility zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
+  description = "List of public cidrs, for every availability zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
 }
 
 variable "load_balancers" {
@@ -34,7 +34,7 @@ variable "load_balancers" {
 
 variable "availability_zones" {
   type        = list
-  description = "List of avalibility zones you want. Example: eu-west-1a and eu-west-1b"
+  description = "List of availability zones you want. Example: eu-west-1a and eu-west-1b"
 }
 
 variable "max_size" {

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -13,17 +13,17 @@ variable "destination_cidr_block" {
 
 variable "private_subnet_cidrs" {
   type        = list
-  description = "List of private cidrs, for every avalibility zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
+  description = "List of private cidrs, for every availability zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
 }
 
 variable "public_subnet_cidrs" {
   type        = list
-  description = "List of public cidrs, for every avalibility zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
+  description = "List of public cidrs, for every availability zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
 }
 
 variable "availability_zones" {
   type        = list
-  description = "List of avalibility zones you want. Example: eu-west-1a and eu-west-1b"
+  description = "List of availability zones you want. Example: eu-west-1a and eu-west-1b"
 }
 
 variable "depends_id" {}

--- a/modules/subnet/variables.tf
+++ b/modules/subnet/variables.tf
@@ -8,14 +8,14 @@ variable "environment" {
 
 variable "cidrs" {
   type        = list
-  description = "List of cidrs, for every avalibility zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
+  description = "List of cidrs, for every availability zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
 }
 
 variable "availability_zones" {
   type        = list
-  description = "List of avalibility zones you want. Example: eu-west-1a and eu-west-1b"
+  description = "List of availability zones you want. Example: eu-west-1a and eu-west-1b"
 }
 
 variable "vpc_id" {
-  description = "VPC id to place to subnet into"
+  description = "VPC id to place subnet into"
 }


### PR DESCRIPTION
Fix typos in variable descriptions.

- avalibility -> availability
- "VPC id to place to subnet into" -> "VPC id to place subnet into"