### PR TITLE
Derive availability_zones from aws datasource and remove from configs.

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -11,7 +11,6 @@ module "ecs" {
   vpc_cidr             = var.vpc_cidr
   public_subnet_cidrs  = var.public_subnet_cidrs
   private_subnet_cidrs = var.private_subnet_cidrs
-  availability_zones   = var.availability_zones
   max_size             = var.max_size
   min_size             = var.min_size
   desired_capacity     = var.desired_capacity
@@ -41,9 +40,6 @@ variable "public_subnet_cidrs" {
   type = list
 }
 
-variable "availability_zones" {
-  type = list
-}
 
 output "default_alb_target_group" {
   value = module.ecs.default_alb_target_group

--- a/ecs.tfvars
+++ b/ecs.tfvars
@@ -6,8 +6,6 @@ public_subnet_cidrs = ["10.0.0.0/24", "10.0.1.0/24"]
 
 private_subnet_cidrs = ["10.0.50.0/24", "10.0.51.0/24"]
 
-availability_zones = ["eu-west-1a", "eu-west-1b"]
-
 max_size = 1
 
 min_size = 1

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -4,7 +4,6 @@ module "network" {
   vpc_cidr             = var.vpc_cidr
   public_subnet_cidrs  = var.public_subnet_cidrs
   private_subnet_cidrs = var.private_subnet_cidrs
-  availability_zones   = var.availability_zones
   depends_id           = ""
 }
 

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -32,11 +32,6 @@ variable "load_balancers" {
   description = "The load balancers to couple to the instances"
 }
 
-variable "availability_zones" {
-  type        = list
-  description = "List of availability zones you want. Example: eu-west-1a and eu-west-1b"
-}
-
 variable "max_size" {
   description = "Maximum size of the nodes in the cluster"
 }

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -1,3 +1,7 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 module "vpc" {
   source = "../vpc"
 
@@ -12,7 +16,7 @@ module "private_subnet" {
   environment        = var.environment
   vpc_id             = module.vpc.id
   cidrs              = var.private_subnet_cidrs
-  availability_zones = var.availability_zones
+  availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 }
 
 module "public_subnet" {
@@ -22,7 +26,7 @@ module "public_subnet" {
   environment        = var.environment
   vpc_id             = module.vpc.id
   cidrs              = var.public_subnet_cidrs
-  availability_zones = var.availability_zones
+  availability_zones = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
 }
 
 module "nat" {

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -21,9 +21,4 @@ variable "public_subnet_cidrs" {
   description = "List of public cidrs, for every availability zone you want you need one. Example: 10.0.0.0/24 and 10.0.1.0/24"
 }
 
-variable "availability_zones" {
-  type        = list
-  description = "List of availability zones you want. Example: eu-west-1a and eu-west-1b"
-}
-
 variable "depends_id" {}


### PR DESCRIPTION
- Remove `availability_zones` root var.
- Source `availability_zones` from `aws_availability_zones` datasource in network module.
- Remove piping through of `availability_zones` variable to network module.

This reduces required configuration, but also reduces configurability from root vars without modifying the network module itself. It's a win in my book. It may or may not be one in yours ;).