### PR TITLE
Configure aws provider from root vars and make repository region-agnostic.

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -1,5 +1,6 @@
 provider "aws" {
-  region = "eu-west-1"
+  region  = var.aws_region
+  profile = var.aws_profile
 }
 
 module "ecs" {
@@ -17,7 +18,7 @@ module "ecs" {
   desired_capacity     = var.desired_capacity
   key_name             = aws_key_pair.ecs.key_name
   instance_type        = var.instance_type
-  ecs_aws_ami          = var.ecs_aws_ami
+  ecs_aws_ami          = var.aws_ecs_ami
 }
 
 resource "aws_key_pair" "ecs" {
@@ -36,7 +37,15 @@ variable "ecs_aws_ami" {}
 variable "private_subnet_cidrs" {
   type = list
 }
-
+variable "aws_profile" {
+  description = "The AWS-CLI profile for the account to create resources in."
+}
+variable "aws_region" {
+  description = "The AWS region to create resources in."
+}
+variable "aws_ecs_ami" {
+  description = "The AMI to seed ECS instances with."
+}
 variable "public_subnet_cidrs" {
   type = list
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -32,7 +32,6 @@ variable "max_size" {}
 variable "min_size" {}
 variable "desired_capacity" {}
 variable "instance_type" {}
-variable "ecs_aws_ami" {}
 
 variable "private_subnet_cidrs" {
   type = list

--- a/ecs.tfvars
+++ b/ecs.tfvars
@@ -1,3 +1,13 @@
+# The AWS-CLI profile for the account to create resources in.
+aws_profile = "default"
+
+# The AWS region to create resources in.
+aws_region = "us-east-1"
+
+# The AMI to seed ECS instances with.
+# Leave empty to use the latest Linux 2 ECS-optimized AMI by Amazon.
+aws_ecs_ami = ""
+
 vpc_cidr = "10.0.0.0/16"
 
 environment = "acc"
@@ -15,5 +25,3 @@ min_size = 1
 desired_capacity = 1
 
 instance_type = "t2.micro"
-
-ecs_aws_ami = "ami-95f8d2f3"

--- a/ecs.tfvars
+++ b/ecs.tfvars
@@ -2,7 +2,7 @@
 aws_profile = "default"
 
 # The AWS region to create resources in.
-aws_region = "us-east-1"
+aws_region = "eu-west-1"
 
 # The AMI to seed ECS instances with.
 # Leave empty to use the latest Linux 2 ECS-optimized AMI by Amazon.

--- a/modules/ecs_instances/main.tf
+++ b/modules/ecs_instances/main.tf
@@ -3,6 +3,25 @@
 # environment, cluster name en the instance_group name.
 # That is also the reason why ecs_instances is a seperate module and not everything is created here.
 
+data "aws_region" "current" {}
+
+# Get latest Linux 2 ECS-optimized AMI by Amazon
+data "aws_ami" "latest_ecs_ami" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-ecs-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["amazon"]
+}
+
 resource "aws_security_group" "instance" {
   name        = "${var.environment}_${var.cluster}_${var.instance_group}"
   description = "Used in ${var.environment}"
@@ -29,7 +48,7 @@ resource "aws_security_group_rule" "outbound_internet_access" {
 # Default disk size for Docker is 22 gig, see http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
 resource "aws_launch_configuration" "launch" {
   name_prefix          = "${var.environment}_${var.cluster}_${var.instance_group}_"
-  image_id             = var.aws_ami
+  image_id             = var.aws_ami != "" ? var.aws_ami : data.aws_ami.latest_ecs_ami.image_id
   instance_type        = var.instance_type
   security_groups      = ["${aws_security_group.instance.id}"]
   user_data            = data.template_file.user_data.rendered
@@ -92,6 +111,7 @@ data "template_file" "user_data" {
   template = "${file("${path.module}/templates/user_data.sh")}"
 
   vars = {
+    region            = data.aws_region.current.name
     ecs_config        = var.ecs_config
     ecs_logging       = var.ecs_logging
     cluster_name      = var.cluster

--- a/modules/ecs_instances/main.tf
+++ b/modules/ecs_instances/main.tf
@@ -3,8 +3,6 @@
 # environment, cluster name, and the instance_group name.
 # That is also the reason why ecs_instances is a seperate module and not everything is created here.
 
-data "aws_region" "current" {}
-
 # Get latest Linux 2 ECS-optimized AMI by Amazon
 data "aws_ami" "latest_ecs_ami" {
   most_recent = true
@@ -111,7 +109,6 @@ data "template_file" "user_data" {
   template = "${file("${path.module}/templates/user_data.sh")}"
 
   vars = {
-    region            = data.aws_region.current.name
     ecs_config        = var.ecs_config
     ecs_logging       = var.ecs_logging
     cluster_name      = var.cluster

--- a/modules/ecs_instances/templates/user_data.sh
+++ b/modules/ecs_instances/templates/user_data.sh
@@ -57,8 +57,9 @@ EOF
 # Get availability zone where the container instance is located and remove the trailing character to give us the region.
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
 region=$(curl 169.254.169.254/latest/meta-data/placement/availability-zone | sed s'/.$//')
-# Replace the logging region specified by our region env var with the region where the container instance is located.
-sed -i -e "s/region = ${region}/region = $region/g" /etc/awslogs/awscli.conf
+# Replace the default log region with the region where the container instance is located.
+# https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/QuickStartEC2Instance.html#running-ec2-step-2
+sed -i -e "s/region = us-east-1/region = $region/g" /etc/awslogs/awscli.conf
 
 # Set the ip address of the node 
 # Get the ipv4 of the container instance

--- a/modules/ecs_instances/templates/user_data.sh
+++ b/modules/ecs_instances/templates/user_data.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-# Timezone
-ln -fs /usr/share/zoneinfo/Europe/Amsterdam /etc/localtime
-
-#Using script from http://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_cloudwatch_logs.html
+# Using script from http://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_cloudwatch_logs.html
 # Install awslogs and the jq JSON parser
 yum install -y awslogs jq aws-cli
 
@@ -58,7 +55,7 @@ EOF
 
 # Set the region to send CloudWatch Logs data to (the region where the container instance is located)
 region=$(curl 169.254.169.254/latest/meta-data/placement/availability-zone | sed s'/.$//')
-sed -i -e "s/region = us-east-1/region = $region/g" /etc/awslogs/awscli.conf
+sed -i -e "s/region = ${region}/region = $region/g" /etc/awslogs/awscli.conf
 
 # Set the ip address of the node 
 container_instance_id=$(curl 169.254.169.254/latest/meta-data/local-ipv4)


### PR DESCRIPTION
- Define aws region with variable `aws_region` in **ecs.tfvars**.
- Define aws profile with variable `aws_profile` in **ecs.tfvars**.
- Change name of `ecs_aws_ami` variable to `aws_ecs_ami` in **ecs.tfvars** for consistency.
- Use latest Linux 2 ECS-optimized AMI if none specified (default).
  - Accomplishing this via `aws_ami` datasource.
- Replace hardcoded region in `user_data.sh` with current region from `aws_region` datasource.
- Remove region-specific timezone specification from `user_data.sh`, which is no longer necessary with Linux 2 AMI.