### PR TITLE
fix: full form of ecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Features:
 
 ## What is ECS
 
-ECS stands for EC2 Container Service and is the AWS platform for running Docker containers.
+ECS stands for Elastic Container Service and is the AWS platform for running Docker containers.
 The full documentation about ECS can be found [here](https://aws.amazon.com/ecs/), the development guide can be found [here](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/Welcome.html). A more fun read can be found at [The Hitchhiker's Guide to AWS ECS and Docker](http://start.jcolemorrison.com/the-hitchhikers-guide-to-aws-ecs-and-docker/).
 
 To understand ECS it is good to state the obvious differences against the competitors like [Kubernetes](https://kubernetes.io/) or [DC/OS Mesos](https://docs.mesosphere.com/). The major differences are that ECS can not be run on-prem and that it lacks advanced features. These two differences can either been seen as weakness or as strengths.


### PR DESCRIPTION
I found a mistake in README. ECS stands for Elastic Container Service.
https://aws.amazon.com/ecs/?whats-new-cards.sort-by=item.additionalFields.postDateTime&whats-new-cards.sort-order=desc&ecs-blogs.sort-by=item.additionalFields.createdDate&ecs-blogs.sort-order=desc
